### PR TITLE
Fix typo in Signed Out page heading

### DIFF
--- a/src/app/signed-out/page.tsx
+++ b/src/app/signed-out/page.tsx
@@ -14,7 +14,7 @@ export default function SignedOutPage() {
 
   return (
     <div className="py-24 mx-auto max-w-[400px] space-y-6">
-      <h1 className={pageTitleStyles}>Successfull Signed Out</h1>
+      <h1 className={pageTitleStyles}>Successfully Signed Out</h1>
       <p className="text-xl">
         You have been successfully signed out. You can now sign in to your
         account.


### PR DESCRIPTION
Correct spelling of "Successfull" to "Successfully" on the Signed Out page.