### PR TITLE
Add missing db/migrate.ts script

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -4,7 +4,7 @@ import { drizzle } from "drizzle-orm/libsql";
 import { createClient } from "@libsql/client";
 import { env } from "@/env";
 
-const client = createClient({
+export const client = createClient({
   url: env.DATABASE_URL!,
   authToken: env.DB_AUTH_TOKEN!,
 });

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -1,0 +1,8 @@
+import "dotenv/config";
+import { migrate } from "drizzle-orm/libsql/migrator";
+import { client, db } from ".";
+
+(async () => {
+  await migrate(db, { migrationsFolder: "./migrations" });
+  client.close();
+})();


### PR DESCRIPTION
I copied template from https://orm.drizzle.team/docs/migrations and modified to work with SQLite adapter that we have.
If you run the `npm run db:migrate` you will get a missing journal error. And this is due to the lack of actual migrations. You need to run `npm run db:generate` first.

I didn't run it and didn't include migrations into the template because user might want to change tables prefix. If tables prefix changes then user will have to regenerate all migrations.

Generally speaking I would change README.md to use migrations approach instead of `db:push`. It's anti-pattern to `db:push` directly into production database. You never know how does the final push migration looks like.