### PR TITLE
Redirect user based on auth

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,7 +1,9 @@
-import { assertAuthenticated } from "@/lib/session";
+import { getCurrentUser } from "@/lib/session";
+import { redirect } from "next/navigation";
 
 export default async function DashboardPage() {
-  await assertAuthenticated();
+  const user = await getCurrentUser();
+  if (!user) redirect("/sign-in");
 
   return (
     <div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,8 @@
+import { getCurrentUser } from "@/lib/session";
 import { redirect } from "next/navigation";
 
 export default async function HomePage() {
+  const user = await getCurrentUser();
+  if (user) redirect("/dashboard");
   redirect("/sign-in");
 }


### PR DESCRIPTION
we redirect users based on their auth status 

- we use getCurrentUser() instead of assertAuthenticated() in the dashboard page
- for the auth pages I tried to redirect with middleware but Libsql threw an error ( I think its edge related thing )

```sh
LibsqlError: URL_SCHEME_NOT_SUPPORTED: The client that uses Web standard APIs supports only "libsql:", "wss:", "ws:", "https:" and "http:" URLs, got "file:". For more information, please read https://github.com/libsql/libsql-client-ts#supported-urls 
```
- doing auth pages redirect in a layout is not the best approach since the layout does not refetch