### PR TITLE
SQLite unique constraint error

### DIFF
--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -23,11 +23,21 @@ export const assertAuthenticated = async () => {
 };
 
 export async function setSession(userId: UserId) {
-  const session = await lucia.createSession(userId, {});
-  const sessionCookie = lucia.createSessionCookie(session.id);
-  cookies().set(
-    sessionCookie.name,
-    sessionCookie.value,
-    sessionCookie.attributes
-  );
+  const existingSessions = await lucia.getUserSessions(userId);
+  if (existingSessions.length > 0) {
+    const sessionCookie = lucia.createSessionCookie(existingSessions[0].id);
+    cookies().set(
+      sessionCookie.name,
+      sessionCookie.value,
+      sessionCookie.attributes,
+    );
+  } else {
+    const session = await lucia.createSession(userId, {});
+    const sessionCookie = lucia.createSessionCookie(session.id);
+    cookies().set(
+      sessionCookie.name,
+      sessionCookie.value,
+      sessionCookie.attributes,
+    );
+  }
 }


### PR DESCRIPTION
This issue arises when a user tries to log in when a session already exists in the db.
This PR uses an existing session instead of creating a new one because SQLite throws a unique constraint on the sessions table.
There are many other ways to solve it but I thought this is this the fastest one.
`lucia.getUserSessions` returns an empty array if there is no sessions for the userId, and an array of sessions otherwise.