### PR TITLE
fix: delete all sessions on password change

### DIFF
--- a/src/data-access/sessions.ts
+++ b/src/data-access/sessions.ts
@@ -3,10 +3,6 @@ import { sessions } from "@/db/schema";
 import { UserId } from "@/use-cases/types";
 import { eq } from "drizzle-orm";
 
-export async function deleteSessionForUser(userId: UserId) {
-  await db.delete(sessions).where(eq(sessions.userId, userId));
-}
-
-export async function deleteAllSessions(userId: UserId, trx = db) {
+export async function deleteSessionForUser(userId: UserId, trx = db) {
   await trx.delete(sessions).where(eq(sessions.userId, userId));
 }

--- a/src/data-access/sessions.ts
+++ b/src/data-access/sessions.ts
@@ -6,3 +6,7 @@ import { eq } from "drizzle-orm";
 export async function deleteSessionForUser(userId: UserId) {
   await db.delete(sessions).where(eq(sessions.userId, userId));
 }
+
+export async function deleteAllSessions(userId: UserId, trx = db) {
+  await trx.delete(sessions).where(eq(sessions.userId, userId));
+}

--- a/src/use-cases/users.tsx
+++ b/src/use-cases/users.tsx
@@ -38,7 +38,7 @@ import {
 } from "./errors";
 import { db } from "@/db";
 import { createTransaction } from "@/data-access/utils";
-import { deleteAllSessions } from "@/data-access/sessions";
+import { deleteSessionForUser } from "@/data-access/sessions";
 
 export async function deleteUserUseCase(
   authenticatedUser: UserSession,
@@ -153,7 +153,7 @@ export async function changePasswordUseCase(token: string, password: string) {
   await createTransaction(async (trx) => {
     await deletePasswordResetToken(token, trx);
     await updatePassword(userId, password, trx);
-    await deleteAllSessions(userId, trx);
+    await deleteSessionForUser(userId, trx);
   });
 }
 

--- a/src/use-cases/users.tsx
+++ b/src/use-cases/users.tsx
@@ -38,6 +38,7 @@ import {
 } from "./errors";
 import { db } from "@/db";
 import { createTransaction } from "@/data-access/utils";
+import { deleteAllSessions } from "@/data-access/sessions";
 
 export async function deleteUserUseCase(
   authenticatedUser: UserSession,
@@ -152,6 +153,7 @@ export async function changePasswordUseCase(token: string, password: string) {
   await createTransaction(async (trx) => {
     await deletePasswordResetToken(token, trx);
     await updatePassword(userId, password, trx);
+    await deleteAllSessions(userId, trx);
   });
 }
 


### PR DESCRIPTION
Delete all the sessions after the password is changed. This will ensure user is logged out from all the devices after the password change.